### PR TITLE
PLT grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,56 @@ Test cases can be run with
 make test-docker
 ```
 
-For anyone interested in using this as a spark library 
-in order to 
-calculate statistics for ELTs or PLTs or to 
-calculate EP curves for PLTs, 
-the main method in class `RMSPLTAnalyticsExample` and 
+# Using as a Spark Package for PLT Statistics
+
+We describe how to use this package to calculate 
+statistics for PLT records.
+
+We assume that a Spark DataFrame `df` has been defined 
+with the following fields: 
+
+| Field Name     | Type      | Description                                                                       |
+| -------------- | --------- | --------------------------------------------------------------------------------- |
+| SubportfolioId | String    | A subportfolio identifier used for grouping in the calculations of the statistics |
+| PeriodId       | Integer   | A period identifier                                                               |
+| EventId        | Integer   | The event identifier                                                              |
+| EventDate      | Timestamp | The date of the simulated event                                                   |
+| Weight         | Double    | The weight associated with the period                                             |
+| Loss           | Double    | The loss associated with the period and event                                     |
+
+To calculate Average Annual Loss (AAL) and the Standard Deviation, use the following
+```
+spark> val stats = PLT.calculateStatistics(df)
+spark> stats.show(false)
+```
+
+`stats` is a DataFrame containing the PLT statistics AAL, 
+Standard Deviation, and Coefficient of Variation by subportfolio ID.  
+
+To calculate the tail statistics, one can use something like 
+```
+spark> val rps = EPCurve.RETURN_PERIODS.toSeq.map(_.toDouble) // Or: Array[Double](...) for custom values
+spark> val numberOfPeriods = 50000.0 // Specify the total number of periods considered
+spark> val zeroLossRecordWeight =  1.0 / numberOfPeriods
+spark> val pmlsdf = PLT.calculateCombinedPMLForReturnPeriodsBySubportfolio(df, rps, Some(zeroLossRecordWeight))
+spark> // print
+spark> pmlsdf.orderBy(col("SubportfolioId"), col("ReturnPeriod").desc).show(false)
+```
+
+The resulting DataFrame `pmlsdf` contains the _Occurrence Probable Maximum Loss_ (OPML) and
+_Aggregate Probable Maximum Loss_ (APML) by subportfolio ID and return period.  
+We use the terminology _Probable Maximum Loss_ as described in [1] here as 
+we are looking at loss levels associated with return periods.  
+Note that in the documentation from RMS and 
+in the code repository referenced above, RMS often extends the use of the term 
+_Exceedance Probability_ to describe these analytics as well 
+(i.e., you might see these analytics referred to as OEP and AEP in RMS documents).
+
+For anyone interested in using other methods found in this package 
+for calculating statistics for ELTs or PLTs,
+or for calculating EP curves for PLTs,
 the test cases might prove instructive.
+
+# References
+
+1. David Homer and Ming Li, [Notes on Using Property Catastrophe Model Results](https://www.casact.org/sites/default/files/2021-02/2017_most-practical-paper_homer-li.pdf), _Casualty Actuarial Society E-Forum_, Spring 2017-Volume 2 

--- a/README.md
+++ b/README.md
@@ -41,4 +41,5 @@ For anyone interested in using this as a spark library
 in order to 
 calculate statistics for ELTs or PLTs or to 
 calculate EP curves for PLTs, 
+the main method in class `RMSPLTAnalyticsExample` and 
 the test cases might prove instructive.

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization := "com.jvstinian"
 name := "plttools-spark"
-version := "0.1.0"
+version := "0.9.0"
 scalaVersion := "2.11.12" // Scala version needs to match version of Scaala used by Spark
 
 initialize := {
@@ -48,6 +48,7 @@ parallelExecution in Test := false
 val scalaTestVersion = "3.2.9"
 libraryDependencies += "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
 libraryDependencies += "org.scalatest" %% "scalatest-flatspec" % scalaTestVersion % "test"
+libraryDependencies += "org.scalactic" %% "scalactic" % "3.2.11"
 
 // Spark dependencies
 val sparkVersion = "2.4.5"

--- a/src/main/java/EPCurve.java
+++ b/src/main/java/EPCurve.java
@@ -17,7 +17,7 @@ public class EPCurve {
         UNKNOWN
     };
 
-    public static int[] RETURN_PERIODS = new int[] {2, 5, 10, 25, 50, 100, 200, 250, 500, 1000, 5000, 10000};
+    public static int[] RETURN_PERIODS = new int[] {2, 5, 10, 25, 50, 100, 200, 250, 500, 1000, 5000, 10000, 50000};
 
     private EPType epType;
     private double[] probabilities;

--- a/src/main/scala/RMSPLTAnalyticsExample.scala
+++ b/src/main/scala/RMSPLTAnalyticsExample.scala
@@ -4,16 +4,12 @@
  */
 package main.scala
 
+import com.jvstinian.rms.aggregationtools.EPCurve
 import com.jvstinian.rms.aggregationtools.PLTRecord
+import com.jvstinian.rms.aggregationtools.PLT
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.types.DateType
-import org.apache.spark.sql.types.DoubleType
-import org.apache.spark.sql.types.IntegerType
-import org.apache.spark.sql.types.LongType
-import org.apache.spark.sql.types.StringType
-import org.apache.spark.sql.types.StructField
-import org.apache.spark.sql.types.StructType
-
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.lit
 import java.sql.Date
 import java.text.SimpleDateFormat
 import scala.io.Source
@@ -22,17 +18,6 @@ final case class PLTRecordParseException(private val message: String = "", priva
     extends Exception(message, cause)
 
 object PLTRecordParser {
-  type PLTRecordType = (String, Int, Double, Long, Date, Date, Double)
-  val PLTSchema: StructType = StructType(
-    StructField("LossType", StringType, false) ::
-      StructField("PeriodId", IntegerType, false) ::
-      StructField("Weight", DoubleType, false) ::
-      StructField("EventId", LongType, false) ::
-      StructField("EventDate", DateType, false) ::
-      StructField("LossDate", DateType, false) ::
-      StructField("Loss", DoubleType, false) :: Nil
-  )
-
   def parseRecord(record: String): PLTRecord = {
     val format = new SimpleDateFormat("M/d/yyyy HH:mm:ss a")
     record.split(',') match {
@@ -40,7 +25,7 @@ object PLTRecordParser {
         PLTRecord(
           lossType,
           periodIdStr.toInt,
-          weightStr.toDouble, /*BigInt(eventIdStr)*/ eventIdStr.toLong,
+          weightStr.toDouble, eventIdStr.toLong,
           new Date(format.parse(eventDateStr).getTime()),
           new Date(format.parse(lossDateStr).getTime()),
           lossStr.toDouble
@@ -57,16 +42,22 @@ object RMSPLTAnalyticsExample {
       .appName("RMSPLTAnalyticsExample")
       .master("local")
       .getOrCreate()
-    // Source.fromInputStream(getClass.getResourceAsStream("/plt.csv")).getLines().foreach(println)
     val pltrecs = Source
       .fromInputStream(getClass.getResourceAsStream("/plt.csv"))
       .getLines()
       .toSeq
       .tail
       .map(PLTRecordParser.parseRecord)
-    val df = PLTRecord.toDataframe(spark, pltrecs)
+    val df = PLTRecord.toDataframe(spark, pltrecs).withColumn("SubportfolioId", lit("All"))
     df.show(false)
 
+    val rps = EPCurve.RETURN_PERIODS.toSeq.map(_.toDouble)
+    val zeroLossRecordWeight = 1.0 / 50000.0
+    val pmlsdf = PLT.calculateCombinedPMLForReturnPeriodsBySubportfolio(
+      df, rps, Some(zeroLossRecordWeight)
+    )
+    pmlsdf.orderBy(col("SubportfolioId"), col("ReturnPeriod").desc).show(false)
+    
     spark.stop()
   }
 }

--- a/src/main/scala/RMSPLTAnalyticsExample.scala
+++ b/src/main/scala/RMSPLTAnalyticsExample.scala
@@ -26,7 +26,8 @@ object PLTRecordParser {
         PLTRecord(
           lossType,
           periodIdStr.toInt,
-          weightStr.toDouble, eventIdStr.toLong,
+          weightStr.toDouble,
+          eventIdStr.toLong,
           new Date(format.parse(eventDateStr).getTime()),
           new Date(format.parse(lossDateStr).getTime()),
           lossStr.toDouble
@@ -57,10 +58,12 @@ object RMSPLTAnalyticsExample {
     val rps = EPCurve.RETURN_PERIODS.toSeq.map(_.toDouble)
     val zeroLossRecordWeight = 1.0 / 50000.0
     val pmlsdf = PLT.calculateCombinedPMLForReturnPeriodsBySubportfolio(
-      df, rps, Some(zeroLossRecordWeight)
+      df,
+      rps,
+      Some(zeroLossRecordWeight)
     )
     pmlsdf.orderBy(col("SubportfolioId"), col("ReturnPeriod").desc).show(false)
-    
+
     spark.stop()
   }
 }

--- a/src/main/scala/RMSPLTAnalyticsExample.scala
+++ b/src/main/scala/RMSPLTAnalyticsExample.scala
@@ -5,11 +5,12 @@
 package main.scala
 
 import com.jvstinian.rms.aggregationtools.EPCurve
-import com.jvstinian.rms.aggregationtools.PLTRecord
 import com.jvstinian.rms.aggregationtools.PLT
+import com.jvstinian.rms.aggregationtools.PLTRecord
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.functions.lit
+
 import java.sql.Date
 import java.text.SimpleDateFormat
 import scala.io.Source

--- a/src/main/scala/RMSPLTAnalyticsExample.scala
+++ b/src/main/scala/RMSPLTAnalyticsExample.scala
@@ -51,6 +51,8 @@ object RMSPLTAnalyticsExample {
     val df = PLTRecord.toDataframe(spark, pltrecs).withColumn("SubportfolioId", lit("All"))
     df.show(false)
 
+    PLT.calculateStatistics(df).show(false)
+
     val rps = EPCurve.RETURN_PERIODS.toSeq.map(_.toDouble)
     val zeroLossRecordWeight = 1.0 / 50000.0
     val pmlsdf = PLT.calculateCombinedPMLForReturnPeriodsBySubportfolio(

--- a/src/main/scala/aggregationtools/PLT.scala
+++ b/src/main/scala/aggregationtools/PLT.scala
@@ -26,8 +26,8 @@ case class SimplePLTRecord(
 
 // PLTRecord is used for construction a Spark DataFrame.
 // Though this runs contrary to naming conventions,
-// we use uppercase constructor parameters for consistency 
-// with the input field names (and to avoid manual renaming 
+// we use uppercase constructor parameters for consistency
+// with the input field names (and to avoid manual renaming
 // of fields).
 case class PLTRecord(
     LossType: String,
@@ -114,7 +114,7 @@ object PLT {
       .flatMapGroups(calculateEPForReturnPeriods(EPCurve.EPType.AEP, rps, zeroLossRecordWeight))
       .toDF()
   }
-  
+
   def calculateCombinedPMLForReturnPeriodsBySubportfolio(
       pltdf: DataFrame,
       rps: Seq[Double],
@@ -124,11 +124,12 @@ object PLT {
     val opmldf = this.calculateOEPForReturnPeriodsBySubportfolio(groupedPltDf, rps, zeroLossRecordWeight)
     val apmldf = this.calculateAEPForReturnPeriodsBySubportfolio(groupedPltDf, rps, zeroLossRecordWeight)
     val resdf = opmldf.union(apmldf)
-    resdf.groupBy("SubportfolioId", "ReturnPeriod")
-         .pivot("EPType", Seq[String]("OEP", "AEP"))
-         .agg(max(col("Loss")).alias("Loss"))
-         .withColumnRenamed("OEP", "OPML")
-         .withColumnRenamed("AEP", "APML")
+    resdf
+      .groupBy("SubportfolioId", "ReturnPeriod")
+      .pivot("EPType", Seq[String]("OEP", "AEP"))
+      .agg(max(col("Loss")).alias("Loss"))
+      .withColumnRenamed("OEP", "OPML")
+      .withColumnRenamed("AEP", "APML")
   }
 
   def groupPlts(pltdf: DataFrame): DataFrame = pltdf

--- a/src/main/scala/aggregationtools/PLT.scala
+++ b/src/main/scala/aggregationtools/PLT.scala
@@ -127,6 +127,8 @@ object PLT {
     resdf.groupBy("SubportfolioId", "ReturnPeriod")
          .pivot("EPType", Seq[String]("OEP", "AEP"))
          .agg(max(col("Loss")).alias("Loss"))
+         .withColumnRenamed("OEP", "OPML")
+         .withColumnRenamed("AEP", "APML")
   }
 
   def groupPlts(pltdf: DataFrame): DataFrame = pltdf

--- a/src/test/scala/PLTCalculator.scala
+++ b/src/test/scala/PLTCalculator.scala
@@ -12,6 +12,9 @@ import org.apache.spark.sql.functions.lit
 import org.scalatest.Outcome
 import org.scalatest.flatspec.FixtureAnyFlatSpec
 
+// Note that we do not use PLT.groupPlts to aggregate
+// the PLT records here, consistent with the
+// test cases in https://github.com/RMS-Consulting/plttools.
 class PLTCalculatorSpec extends FixtureAnyFlatSpec {
 
   case class FixtureParam(spark: SparkSession, data: DataFrame)

--- a/src/test/scala/SamplePLTCalculator.scala
+++ b/src/test/scala/SamplePLTCalculator.scala
@@ -11,11 +11,13 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.functions.min
+import org.scalactic.Tolerance
 import org.scalatest.Outcome
 import org.scalatest.flatspec.FixtureAnyFlatSpec
-import org.scalactic.Tolerance
-import Tolerance.convertNumericToPlusOrMinusWrapper // Implicit to allow +-
+
 import scala.io.Source
+
+import Tolerance.convertNumericToPlusOrMinusWrapper
 
 class SamplePLTCalculatorSpec extends FixtureAnyFlatSpec {
 
@@ -67,17 +69,17 @@ class SamplePLTCalculatorSpec extends FixtureAnyFlatSpec {
     val lossmap = Map(res: _*)
     assert(lossmap(50000.0) === (3961210646.25 +- 1e-2))
     assert(lossmap(10000.0) === (2566817596.18 +- 1e-2))
-    assert(lossmap( 5000.0) === (1982672189.0  +- 1e-2))
-    assert(lossmap( 1000.0) === (1149500694.43 +- 1e-2))
-    assert(lossmap(  500.0) === (832353773.07 +- 1e-2))
-    assert(lossmap(  250.0) === (580645121.7 +- 1e-2))
-    assert(lossmap(  200.0) === (514043110.58 +- 1e-2))
-    assert(lossmap(  100.0) === (339844342.61 +- 1e-2))
-    assert(lossmap(   50.0) === (198673192.75 +- 1e-2))
-    assert(lossmap(   25.0) === (105494369.44 +- 1e-2))
-    assert(lossmap(   10.0) === (38559130.58 +- 1e-2))
-    assert(lossmap(    5.0) === (13233579.61 +- 1e-2))
-    assert(lossmap(    2.0) === (583871.12 +- 1e-2))
+    assert(lossmap(5000.0) === (1982672189.0 +- 1e-2))
+    assert(lossmap(1000.0) === (1149500694.43 +- 1e-2))
+    assert(lossmap(500.0) === (832353773.07 +- 1e-2))
+    assert(lossmap(250.0) === (580645121.7 +- 1e-2))
+    assert(lossmap(200.0) === (514043110.58 +- 1e-2))
+    assert(lossmap(100.0) === (339844342.61 +- 1e-2))
+    assert(lossmap(50.0) === (198673192.75 +- 1e-2))
+    assert(lossmap(25.0) === (105494369.44 +- 1e-2))
+    assert(lossmap(10.0) === (38559130.58 +- 1e-2))
+    assert(lossmap(5.0) === (13233579.61 +- 1e-2))
+    assert(lossmap(2.0) === (583871.12 +- 1e-2))
   }
 
   "Test AEP calculations" should "all have EPType \"AEP\"" in { fixture =>
@@ -91,8 +93,8 @@ class SamplePLTCalculatorSpec extends FixtureAnyFlatSpec {
 
   // In the original python test cases, there was no test
   // for the AEP calculations for the sample csv file.
-  // We have used the Jupyter notebook to generate values 
-  // for the standard return periods, and have added the 
+  // We have used the Jupyter notebook to generate values
+  // for the standard return periods, and have added the
   // following test for the AEP calculations using spark.
   it should "should have values" in { fixture =>
     val zeroLossRecordWeight = 1.0 / 50000.0
@@ -102,17 +104,17 @@ class SamplePLTCalculatorSpec extends FixtureAnyFlatSpec {
     val lossmap = Map(res: _*)
     assert(lossmap(50000.0) === (4458481476.37 +- 1e-2))
     assert(lossmap(10000.0) === (2567302366.31 +- 1e-2))
-    assert(lossmap( 5000.0) === (2066233259.4 +- 1e-2))
-    assert(lossmap( 1000.0) === (1268780632.3200002 +- 1e-2))
-    assert(lossmap(  500.0) === (901186582.9999999 +- 1e-2))
-    assert(lossmap(  250.0) === (631468361.0500001 +- 1e-2))
-    assert(lossmap(  200.0) === (557699753.47 +- 1e-2))
-    assert(lossmap(  100.0) === (369668338.56 +- 1e-2))
-    assert(lossmap(   50.0) === (225176137.1 +- 1e-2))
-    assert(lossmap(   25.0) === (120435807.74 +- 1e-2))
-    assert(lossmap(   10.0) === (44769969.04 +- 1e-2))
-    assert(lossmap(    5.0) === (15443202.180000002 +- 1e-2))
-    assert(lossmap(    2.0) === (672148.1900000001 +- 1e-2))
+    assert(lossmap(5000.0) === (2066233259.4 +- 1e-2))
+    assert(lossmap(1000.0) === (1268780632.3200002 +- 1e-2))
+    assert(lossmap(500.0) === (901186582.9999999 +- 1e-2))
+    assert(lossmap(250.0) === (631468361.0500001 +- 1e-2))
+    assert(lossmap(200.0) === (557699753.47 +- 1e-2))
+    assert(lossmap(100.0) === (369668338.56 +- 1e-2))
+    assert(lossmap(50.0) === (225176137.1 +- 1e-2))
+    assert(lossmap(25.0) === (120435807.74 +- 1e-2))
+    assert(lossmap(10.0) === (44769969.04 +- 1e-2))
+    assert(lossmap(5.0) === (15443202.180000002 +- 1e-2))
+    assert(lossmap(2.0) === (672148.1900000001 +- 1e-2))
   }
 
   "Test AAL" should "have value" in { fixture =>
@@ -124,7 +126,7 @@ class SamplePLTCalculatorSpec extends FixtureAnyFlatSpec {
     val sd = PLT.calculateStandardDeviation(fixture.data).select("StdDev").first().getDouble(0)
     assert(sd === (91165041.19825359 +- 1e-6))
   }
-  
+
   "Test statistics" should "have columns" in { fixture =>
     val stats = PLT.calculateStatistics(fixture.data)
     assert(stats.columns.deep == Array[String]("SubportfolioId", "AAL", "StdDev", "CV").deep)


### PR DESCRIPTION
We add a method for a preliminary grouping of PLT records for properly aggregating records by period and event.  This is a particularly important step for calculating Occurrence Exceedance Probability (OEP) and Probable Maximum Loss (OPML) for Period Loss Tables (PLTs).  

We also 
* update the README with additional information for using the spark package, 
* correct the test case for calculating the OPML for the sample csv file, 
* add a test case for calculating the APML for the sample csv file, 
* add test cases for the AAL and Standard Deviation calculations for the sample csv file, and 
* update the main class to calculate the tail statistics for the sample csv file.  
 